### PR TITLE
ckpem: make pem_objs a list instead of array

### DIFF
--- a/src/ckpem.h
+++ b/src/ckpem.h
@@ -194,6 +194,7 @@ struct pemInternalObjectStr {
   CK_OBJECT_CLASS objClass;
   NSSItem         hashKey;
   NSSItem         id;
+  long            objid;
   unsigned char   hashKeyData[128];
   SECItem         *derCert;
   char            *nickname;

--- a/src/ckpem.h
+++ b/src/ckpem.h
@@ -39,6 +39,8 @@
 #ifndef CKPEM_H
 #define CKPEM_H
 
+#include "list.h"
+
 #define USE_UTIL_DIRECTLY
 #include <utilrename.h>
 
@@ -197,8 +199,13 @@ struct pemInternalObjectStr {
   char            *nickname;
   NSSCKMDObject   mdObject;
   CK_SLOT_ID      slotID;
-  CK_ULONG        gobjIndex;
   int             refCount;
+
+  /* all internal objects are linked in a global list */
+  struct list_head gl_list;
+
+  /* we represent sparse array as list but keep its elements indexed */
+  long            arrayIdx;
 
   /* used by pem_mdFindObjects_Next */
   CK_BBOOL        extRef;
@@ -208,7 +215,7 @@ struct pemInternalObjectStr {
   pemObjectListItem *list;
 };
 
-NSS_EXTERN_DATA pemInternalObject **pem_objs;
+NSS_EXTERN_DATA struct list_head pem_objs;
 NSS_EXTERN_DATA int pem_nobjs;
 NSS_EXTERN_DATA int token_needsLogin[];
 NSS_EXTERN_DATA NSSCKMDSlot *lastEventSlot;

--- a/src/ckpem.h
+++ b/src/ckpem.h
@@ -216,7 +216,7 @@ struct pemInternalObjectStr {
 };
 
 NSS_EXTERN_DATA struct list_head pem_objs;
-NSS_EXTERN_DATA int pem_nobjs;
+NSS_EXTERN_DATA long pem_nobjs;
 NSS_EXTERN_DATA int token_needsLogin[];
 NSS_EXTERN_DATA NSSCKMDSlot *lastEventSlot;
 
@@ -304,7 +304,7 @@ PRBool pem_ParseString(const char *inputstring, const char delimiter,
 
 pemInternalObject *
 AddObjectIfNeeded(CK_OBJECT_CLASS objClass, pemObjectType type,
-                  SECItem *certDER, SECItem *keyDER, const char *filename, int objid,
+                  SECItem *certDER, SECItem *keyDER, const char *filename, long objid,
                   CK_SLOT_ID slotID, PRBool *pAdded);
 
 void pem_DestroyInternalObject (pemInternalObject *io);

--- a/src/list.h
+++ b/src/list.h
@@ -1,0 +1,170 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _LINUX_LIST_H
+#define _LINUX_LIST_H
+
+/* simplified for our use case */
+#define READ_ONCE(x) (x)
+#define WRITE_ONCE(dst, src) (dst = (src))
+#define typeof(x) __typeof__(x)
+# define POISON_POINTER_DELTA 0
+
+/* following code is taken from <linux/list.h> of v4.20-rc7-202-g1d51b4b1d3f2 */
+
+/**
+ * container_of - cast a member of a structure out to the containing structure
+ * @ptr:    the pointer to the member.
+ * @type:   the type of the container struct this is embedded in.
+ * @member: the name of the member within the struct.
+ *
+ */
+#define container_of(ptr, type, member) ({              \
+    void *__mptr = (void *)(ptr);                   \
+    ((type *)(__mptr - offsetof(type, member))); })
+
+/*
+ * These are non-NULL pointers that will result in page faults
+ * under normal circumstances, used to verify that nobody uses
+ * non-initialized list entries.
+ */
+#define LIST_POISON1  ((void *) 0x100 + POISON_POINTER_DELTA)
+#define LIST_POISON2  ((void *) 0x200 + POISON_POINTER_DELTA)
+
+struct list_head {
+	struct list_head *next, *prev;
+};
+
+/*
+ * Simple doubly linked list implementation.
+ *
+ * Some of the internal functions ("__xxx") are useful when
+ * manipulating whole lists rather than single entries, as
+ * sometimes we already know the next/prev entries and we can
+ * generate better code by using them directly rather than
+ * using the generic single-entry routines.
+ */
+
+#define LIST_HEAD_INIT(name) { &(name), &(name) }
+
+#define LIST_HEAD(name) \
+	struct list_head name = LIST_HEAD_INIT(name)
+
+static inline void INIT_LIST_HEAD(struct list_head *list)
+{
+	WRITE_ONCE(list->next, list);
+	list->prev = list;
+}
+
+/*
+ * Insert a new entry between two known consecutive entries.
+ *
+ * This is only for internal list manipulation where we know
+ * the prev/next entries already!
+ */
+static inline void __list_add(struct list_head *new,
+			      struct list_head *prev,
+			      struct list_head *next)
+{
+	next->prev = new;
+	new->next = next;
+	new->prev = prev;
+	WRITE_ONCE(prev->next, new);
+}
+
+/**
+ * list_add - add a new entry
+ * @new: new entry to be added
+ * @head: list head to add it after
+ *
+ * Insert a new entry after the specified head.
+ * This is good for implementing stacks.
+ */
+static inline void list_add(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head, head->next);
+}
+
+
+/**
+ * list_add_tail - add a new entry
+ * @new: new entry to be added
+ * @head: list head to add it before
+ *
+ * Insert a new entry before the specified head.
+ * This is useful for implementing queues.
+ */
+static inline void list_add_tail(struct list_head *new, struct list_head *head)
+{
+	__list_add(new, head->prev, head);
+}
+
+/*
+ * Delete a list entry by making the prev/next entries
+ * point to each other.
+ *
+ * This is only for internal list manipulation where we know
+ * the prev/next entries already!
+ */
+static inline void __list_del(struct list_head * prev, struct list_head * next)
+{
+	next->prev = prev;
+	WRITE_ONCE(prev->next, next);
+}
+
+/**
+ * list_del - deletes entry from list.
+ * @entry: the element to delete from the list.
+ * Note: list_empty() on entry does not return true after this, the entry is
+ * in an undefined state.
+ */
+static inline void __list_del_entry(struct list_head *entry)
+{
+	__list_del(entry->prev, entry->next);
+}
+
+static inline void list_del(struct list_head *entry)
+{
+	__list_del_entry(entry);
+	entry->next = LIST_POISON1;
+	entry->prev = LIST_POISON2;
+}
+
+/**
+ * list_entry - get the struct for this entry
+ * @ptr:	the &struct list_head pointer.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_entry(ptr, type, member) \
+	container_of(ptr, type, member)
+
+/**
+ * list_first_entry - get the first element from a list
+ * @ptr:	the list head to take the element from.
+ * @type:	the type of the struct this is embedded in.
+ * @member:	the name of the list_head within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_first_entry(ptr, type, member) \
+	list_entry((ptr)->next, type, member)
+
+/**
+ * list_next_entry - get the next element in list
+ * @pos:	the type * to cursor
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_next_entry(pos, member) \
+	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/**
+ * list_for_each_entry	-	iterate over list of given type
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_head within the struct.
+ */
+#define list_for_each_entry(pos, head, member)				\
+	for (pos = list_first_entry(head, typeof(*pos), member);	\
+	     &pos->member != (head);					\
+	     pos = list_next_entry(pos, member))
+
+#endif

--- a/src/list.h
+++ b/src/list.h
@@ -149,12 +149,31 @@ static inline void list_del(struct list_head *entry)
 	list_entry((ptr)->next, type, member)
 
 /**
+ * list_last_entry - get the last element from a list
+ * @ptr:    the list head to take the element from.
+ * @type:   the type of the struct this is embedded in.
+ * @member: the name of the list_head within the struct.
+ *
+ * Note, that list is expected to be not empty.
+ */
+#define list_last_entry(ptr, type, member) \
+    list_entry((ptr)->prev, type, member)
+
+/**
  * list_next_entry - get the next element in list
  * @pos:	the type * to cursor
  * @member:	the name of the list_head within the struct.
  */
 #define list_next_entry(pos, member) \
 	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/**
+ * list_prev_entry - get the prev element in list
+ * @pos:    the type * to cursor
+ * @member: the name of the list_head within the struct.
+ */
+#define list_prev_entry(pos, member) \
+    list_entry((pos)->member.prev, typeof(*(pos)), member)
 
 /**
  * list_for_each_entry	-	iterate over list of given type
@@ -166,5 +185,16 @@ static inline void list_del(struct list_head *entry)
 	for (pos = list_first_entry(head, typeof(*pos), member);	\
 	     &pos->member != (head);					\
 	     pos = list_next_entry(pos, member))
+
+/**
+ * list_for_each_entry_reverse - iterate backwards over list of given type.
+ * @pos:    the type * to use as a loop cursor.
+ * @head:   the head for your list.
+ * @member: the name of the list_head within the struct.
+ */
+#define list_for_each_entry_reverse(pos, head, member)          \
+    for (pos = list_last_entry(head, typeof(*pos), member);     \
+         &pos->member != (head);                    \
+         pos = list_prev_entry(pos, member))
 
 #endif

--- a/src/list.h
+++ b/src/list.h
@@ -6,7 +6,7 @@
 #define READ_ONCE(x) (x)
 #define WRITE_ONCE(dst, src) (dst = (src))
 #define typeof(x) __typeof__(x)
-# define POISON_POINTER_DELTA 0
+#define POISON_POINTER_DELTA 0
 
 /* following code is taken from <linux/list.h> of v4.20-rc7-202-g1d51b4b1d3f2 */
 

--- a/src/pfind.c
+++ b/src/pfind.c
@@ -259,7 +259,7 @@ collect_objects(CK_ATTRIBUTE_PTR pTemplate,
 
     plog("collect_objects slot #%ld, ", slotID);
     plog("%d attributes, ", ulAttributeCount);
-    plog("%d objects created in total.\n", pem_nobjs);
+    plog("%ld objects created in total.\n", pem_nobjs);
     plog("Looking for: ");
     /*
      * now determine type of the object

--- a/src/pinst.c
+++ b/src/pinst.c
@@ -195,6 +195,7 @@ assignObjectID(pemInternalObject *o, const long objid)
         return CKR_HOST_MEMORY;
 
     memcpy(o->id.data, id, len);
+    o->objid = objid;
     return CKR_OK;
 }
 
@@ -365,7 +366,7 @@ LinkSharedKeyObject(const long oldKeyIdx, const long newKeyIdx)
     pemInternalObject *obj;
     list_for_each_entry(obj, &pem_objs, gl_list) {
         CK_RV rv;
-        if (atol(obj->id.data) != oldKeyIdx)
+        if (obj->objid != oldKeyIdx)
             continue;
 
         NSS_ZFreeIf(obj->id.data);
@@ -427,7 +428,7 @@ AddObjectIfNeeded(CK_OBJECT_CLASS objClass,
             LinkSharedKeyObject(pem_nobjs, curObj->arrayIdx);
 
             if (CKO_CERTIFICATE == objClass) {
-                const long ref = atol(curObj->id.data);
+                const long ref = curObj->objid;
                 if (0 < ref && ref < pem_nobjs && !FindObjectByArrayIdx(ref)) {
                     /* The certificate we are going to reuse refers to an
                      * object that has already been removed.  Make it refer

--- a/src/pobject.c
+++ b/src/pobject.c
@@ -1089,7 +1089,7 @@ pem_CreateObject
     SECItem **derlist = NULL;
     int nobjs = 0;
     int i;
-    int objid;
+    long objid;
 #if 0
     pemToken *token;
 #endif
@@ -1225,7 +1225,7 @@ pem_CreateObject
             if (curObj->type != pemCert)
                 continue;
 
-            if (atoi(curObj->id.data) != pem_nobjs)
+            if (atol(curObj->id.data) != pem_nobjs)
                 /* not a certificate that refers to the key being added */
                 continue;
 

--- a/src/pobject.c
+++ b/src/pobject.c
@@ -1225,7 +1225,7 @@ pem_CreateObject
             if (curObj->type != pemCert)
                 continue;
 
-            if (atol(curObj->id.data) != pem_nobjs)
+            if (curObj->objid != pem_nobjs)
                 /* not a certificate that refers to the key being added */
                 continue;
 

--- a/src/pobject.c
+++ b/src/pobject.c
@@ -1218,7 +1218,7 @@ pem_CreateObject
 
         /* Brute force: find the id of the certificate, if any, in this slot */
         objid = -1;
-        list_for_each_entry(curObj, &pem_objs, gl_list) {
+        list_for_each_entry_reverse(curObj, &pem_objs, gl_list) {
             if (slotID != curObj->slotID)
                 continue;
 

--- a/src/pobject.c
+++ b/src/pobject.c
@@ -672,10 +672,8 @@ pem_DestroyInternalObject
         return;
     }
 
-    if (NULL != pem_objs)
-        /* remove reference to self from the global array */
-        pem_objs[io->gobjIndex] = NULL;
-
+    /* remove self from the global list */
+    list_del(&io->gl_list);
     NSS_ZFreeIf(io);
     return;
 }
@@ -1206,7 +1204,7 @@ pem_CreateObject
                 goto loser;
         }
     } else if (objClass == CKO_PRIVATE_KEY) {
-        int i;
+        pemInternalObject *curObj;
         SECItem certDER;
         PRBool added;
 
@@ -1220,30 +1218,27 @@ pem_CreateObject
 
         /* Brute force: find the id of the certificate, if any, in this slot */
         objid = -1;
-        for (i = pem_nobjs - 1; 0 <= i; i--) {
-            if (NULL == pem_objs[i])
+        list_for_each_entry(curObj, &pem_objs, gl_list) {
+            if (slotID != curObj->slotID)
                 continue;
 
-            if (slotID != pem_objs[i]->slotID)
+            if (curObj->type != pemCert)
                 continue;
 
-            if (pem_objs[i]->type != pemCert)
-                continue;
-
-            if (atoi(pem_objs[i]->id.data) != pem_nobjs)
+            if (atoi(curObj->id.data) != pem_nobjs)
                 /* not a certificate that refers to the key being added */
                 continue;
 
             objid = pem_nobjs;
-            certDER.data = NSS_ZAlloc(NULL, pem_objs[i]->derCert->len);
+            certDER.data = NSS_ZAlloc(NULL, curObj->derCert->len);
 
             if (certDER.data == NULL)
                 goto loser;
 
-            certDER.len = pem_objs[i]->derCert->len;
+            certDER.len = curObj->derCert->len;
             memcpy(certDER.data,
-                    pem_objs[i]->derCert->data,
-                    pem_objs[i]->derCert->len);
+                    curObj->derCert->data,
+                    curObj->derCert->len);
             break;
         }
 

--- a/src/psession.c
+++ b/src/psession.c
@@ -241,7 +241,7 @@ pem_mdSession_Login
     NSSLOWKEYPrivateKey *lpk = NULL;
     PLArenaPool *arena;
     SECItem plain;
-    int i;
+    pemInternalObject *curObj;
 
     fwSlot = NSSCKFWToken_GetFWSlot(fwToken);
     slotID = NSSCKFWSlot_GetSlotID(fwSlot);
@@ -256,12 +256,9 @@ pem_mdSession_Login
     token_needsLogin[slotID - 1] = PR_FALSE;
 
     /* Find the right key object */
-    for (i = 0; i < pem_nobjs; i++) {
-        if (NULL == pem_objs[i])
-            continue;
-
-        if ((slotID == pem_objs[i]->slotID) && (pem_objs[i]->type == pemBareKey)) {
-            io = pem_objs[i];
+    list_for_each_entry(curObj, &pem_objs, gl_list) {
+        if ((slotID == curObj->slotID) && (curObj->type == pemBareKey)) {
+            io = curObj;
             break;
         }
     }


### PR DESCRIPTION
Since libcurl started to use `PK11_CreateManagedGenericObject()`, the calls to `PK11_DestroyGenericObject()` started to take affect at the level of nss-pem.  Internal objects were removed on each call of `curl_easy_cleanup()` and allocated again on each call of `curl_easy_perform()`.  This would be fine if the corresponding items of the global pem_objects array were reused, which was, however, not the case.  Consequently, the array grew unboundedly while most of its items were NULL pointers.  This caused severe performance regression in libcurl-based applications.

This commit replaces the global array by a global linked list, which allows to delete arbitrary items instead of keeping NULL pointers.  For compatibility reasons, the original array indexes are stored in the list nodes.

Bug: https://bugzilla.redhat.com/1659108