### PR TITLE
On-board on packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,5 @@
+---
+specfile_path: nss-pem.spec
+downstream_package_name: nss-pem
+actions:
+  post-upstream-clone: curl -s -o nss-pem.spec https://src.fedoraproject.org/rpms/nss-pem/raw/master/f/nss-pem.spec


### PR DESCRIPTION
This is minimal set of changes to get on board on packit tool and be able to create SRPMs.

Sadly I hit this bug which in this case makes the produced srpm worthless: https://github.com/packit-service/packit/issues/463

```bash
$ packit srpm
...
Using user-defined script for ActionName.post_upstream_clone: ['curl -s -o nss-pem.spec https://src.fedoraproject.org/rpms/nss-pem/raw/master/f/nss-pem.spec']
12:09:28.640 utils.py          DEBUG  cmd = 'curl -s -o nss-pem.spec https://src.fedoraproject.org/rpms/nss-pem/raw/master/f/nss-pem.spec'
12:09:29.273 utils.py          DEBUG  cmd = 'git describe --tags --match *'
12:09:29.295 upstream.py       DEBUG  version = nss-pem-1.0.5-5-gfb5a6f8
12:09:29.296 upstream.py       DEBUG  sanitized version = nss.pem.1.0.5.5.gfb5a6f8
Version in spec file is '1.0.5'.
10:09:29.378 upstream.py       DEBUG  name + version = nss-pem-nss.pem.1.0.5.5.gfb5a6f8
10:09:29.378 utils.py          DEBUG  cmd = 'git archive -o nss-pem-nss.pem.1.0.5.5.gfb5a6f8.tar.xz --prefix nss-pem-nss.pem.1.0.5.5.gfb5a6f8/ HEAD'
10:09:29.515 upstream.py       DEBUG  present srpms = {PosixPath('/home/tt/g/kdudka/nss-pem/nss-pem-1.0.5-3.dev.gef731636.fc30.src.rpm')}
10:09:29.516 utils.py          DEBUG  cmd = 'rpmbuild -bs --define _sourcedir /home/tt/g/kdudka/nss-pem --define _specdir /home/tt/g/kdudka/nss-pem --define _srcrpmdir /home
/tt/g/kdudka/nss-pem --define _topdir /home/tt/g/kdudka/nss-pem --define _builddir /home/tt/g/kdudka/nss-pem --define _rpmdir /home/tt/g/kdudka/nss-pem --define _buildrootdi
r /home/tt/g/kdudka/nss-pem nss-pem.spec'
10:09:29.796 upstream.py       DEBUG  Wrote: /home/tt/g/kdudka/nss-pem/nss-pem-1.0.5-3.dev.gfb5a6f89.fc30.src.rpm
SRPM is /home/tt/g/kdudka/nss-pem/nss-pem-1.0.5-3.dev.gfb5a6f89.fc30.src.rpm
SRPM: /home/tt/g/kdudka/nss-pem/nss-pem-1.0.5-3.dev.gfb5a6f89.fc30.src.rpm
```

I used newly released packit 0.5.0 (you can get it from updates-testing).

Kamil, I have also briefly skimmed through you srpm script and what packit does is roughly equivalent to it.