### PR TITLE
packit: add epel-7-x86_64 target

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,7 @@ jobs:
       job: copr_build
       trigger: pull_request
       targets:
+          - epel-7-ppc64le
           - epel-7-x86_64
           - fedora-all-ppc64le
           - fedora-all-s390x

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,7 +11,7 @@ jobs:
       job: copr_build
       trigger: pull_request
       targets:
-          - fedora-all-aarch64
+          - epel-7-x86_64
           - fedora-all-ppc64le
           - fedora-all-s390x
           - fedora-all-x86_64

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -92,7 +92,7 @@ License:    MPLv1.1
 URL:        https://github.com/kdudka/nss-pem
 Source0:    https://github.com/kdudka/nss-pem/releases/download/$NV/$SRC
 
-BuildRequires: cmake
+BuildRequires: cmake3
 BuildRequires: gcc
 BuildRequires: make
 BuildRequires: nss-pkcs11-devel
@@ -108,14 +108,14 @@ module.
 %setup -q
 
 %build
-%cmake -S src
-%cmake_build
+%cmake3 -S src
+%cmake3_build
 
 %install
-%cmake_install
+%cmake3_install
 
 %check
-%ctest
+%ctest3
 
 %files
 %{_libdir}/libnsspem.so

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -83,6 +83,9 @@ fi
 
 SPEC="./$PKG.spec"
 cat > "$SPEC" << EOF
+%undefine __cmake_in_source_build
+%undefine __cmake3_in_source_build
+
 Name:       $PKG
 Version:    $VER
 Release:    1%{?dist}


### PR DESCRIPTION
... because nss-pem is used mostly on RHEL-7 these days

Closes: https://github.com/kdudka/nss-pem/pull/16