### PR TITLE
spec: Build with CMake 4 and fix packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,6 +5,7 @@ update_release: false
 actions:
     post-upstream-clone: ./make-srpm.sh --generate-spec
     get-current-version: "sed -n 's|^Version: *||p' nss-pem.spec"
+    post-modifications: "sed -i 's/^Requires: nss%{?_isa}$/Requires: nss%{?_isa} >= %(nss-config --version 2>\\/dev\\/null || echo 0)/' nss-pem.spec"
 
 jobs:
     - &copr

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -91,7 +91,6 @@ fi
 SPEC="./$PKG.spec"
 cat > "$SPEC" << EOF
 %undefine __cmake_in_source_build
-%undefine __cmake3_in_source_build
 
 Name:       $PKG
 Version:    $VER
@@ -105,7 +104,7 @@ License:    GPL-2.0-only AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later)
 URL:        https://github.com/kdudka/nss-pem
 Source0:    https://github.com/kdudka/nss-pem/releases/download/$NV/$SRC
 
-BuildRequires: cmake3
+BuildRequires: cmake
 BuildRequires: gcc
 BuildRequires: make
 BuildRequires: nss-pkcs11-devel
@@ -121,14 +120,14 @@ module.
 %setup -q
 
 %build
-%cmake3 -S src
-%cmake3_build
+%cmake -S src
+%cmake_build
 
 %install
-%cmake3_install
+%cmake_install
 
 %check
-%ctest3
+%ctest
 
 %files
 %{_libdir}/libnsspem.so

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -90,7 +90,11 @@ fi
 
 SPEC="./$PKG.spec"
 cat > "$SPEC" << EOF
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%undefine __cmake3_in_source_build
+%else
 %undefine __cmake_in_source_build
+%endif
 
 Name:       $PKG
 Version:    $VER
@@ -104,7 +108,11 @@ License:    GPL-2.0-only AND (MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later)
 URL:        https://github.com/kdudka/nss-pem
 Source0:    https://github.com/kdudka/nss-pem/releases/download/$NV/$SRC
 
+%if 0%{?rhel} && 0%{?rhel} <= 7
+BuildRequires: cmake3
+%else
 BuildRequires: cmake
+%endif
 BuildRequires: gcc
 BuildRequires: make
 BuildRequires: nss-pkcs11-devel
@@ -120,14 +128,27 @@ module.
 %setup -q
 
 %build
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%cmake3 -S src
+%cmake3_build
+%else
 %cmake -S src
 %cmake_build
+%endif
 
 %install
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%cmake3_install
+%else
 %cmake_install
+%endif
 
 %check
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%ctest3
+%else
 %ctest
+%endif
 
 %files
 %{_libdir}/libnsspem.so

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -60,7 +60,14 @@ test -z "`git diff HEAD`" || VER="${VER}.dirty"
 NV="${PKG}-${VER}"
 printf "\n%s: preparing a release of \033[1;32m%s\033[0m\n\n" "$SELF" "$NV"
 
-if [[ "$1" != "--generate-spec" ]]; then
+NSS_REQ="Requires: nss%{?_isa} >= %(nss-config --version 2>/dev/null || echo 0)"
+if [[ "$1" == "--generate-spec" ]]; then
+    # use a simplified Requires to avoid %(nss-config ...) which breaks
+    # packit's spec parser;  the fix-spec-file action in .packit.yaml
+    # restores the full macro before rpmbuild creates the SRPM
+    NSS_REQ="Requires: nss%{?_isa}"
+else
+    # create source tarball
     TMP="`mktemp -d`"
     trap "rm -rf '$TMP'" EXIT
     cd "$TMP" >/dev/null || die "mktemp failed"
@@ -104,7 +111,7 @@ BuildRequires: make
 BuildRequires: nss-pkcs11-devel
 
 # require at least the version of nss that nss-pem was built against (#1428965)
-Requires: nss%{?_isa} >= %(nss-config --version 2>/dev/null || echo 0)
+$NSS_REQ
 
 %description
 PEM file reader for Network Security Services (NSS), implemented as a PKCS#11


### PR DESCRIPTION
- Build with CMake 4 macros (`%cmake` instead of `%cmake3`), keeping
  cmake3 conditionals for EPEL-7 where `%cmake_build` is not available.
- Work around packit's spec parser choking on `%(nss-config --version ...)`
  by emitting a simplified `Requires` in `--generate-spec` mode and
  restoring the full macro via `post-modifications` before rpmbuild.

Related: https://src.fedoraproject.org/rpms/nss-pem/pull-request/1